### PR TITLE
Allow overlay background color to be customized

### DIFF
--- a/Example/enhance/ENHCollectionViewController.h
+++ b/Example/enhance/ENHCollectionViewController.h
@@ -20,6 +20,7 @@ typedef void(^ENHMenuItemActionBlock)(void);
 @property (nonatomic, copy) ENHMenuItemActionBlock copyImageAction;
 @property (nonatomic, strong) ENHViewController *enhancer;
 @property (nonatomic, strong) NSArray *images;
+@property (nonatomic, copy) NSArray *overlayColors;
 @property (nonatomic, copy) ENHMenuItemActionBlock saveImageAction;
 
 - (void)copyImage:(UIImage *)image;

--- a/Example/enhance/ENHCollectionViewController.m
+++ b/Example/enhance/ENHCollectionViewController.m
@@ -31,6 +31,7 @@
 {
     UIImage *img = self.images[indexPath.item];
     UICollectionViewCell *cell = [self.collectionView cellForItemAtIndexPath:indexPath];
+    self.enhancer.backgroundColor = self.overlayColors[indexPath.item];
     [self.enhancer showImage:img fromView:cell];
 }
 
@@ -157,6 +158,21 @@
                 ];
     
     return _images;
+}
+
+
+- (NSArray *)overlayColors
+{
+    if (_overlayColors) return _overlayColors;
+    
+    _overlayColors = @[
+                          [UIColor colorWithWhite:0 alpha:0.6],
+                          [UIColor colorWithWhite:0 alpha:1],
+                          [UIColor colorWithWhite:1 alpha:1],
+                          [UIColor colorWithRed:200/255. green:10/255. blue:20/255. alpha:0.4]
+                          ];
+    
+    return _overlayColors;
 }
 
 

--- a/Pod/Classes/ENHViewController.h
+++ b/Pod/Classes/ENHViewController.h
@@ -73,6 +73,8 @@ NS_OPTIONS(NSInteger, ENHErrorCode) {
 
 @interface ENHViewController : UIViewController <UIDynamicAnimatorDelegate, UIGestureRecognizerDelegate, NSURLConnectionDataDelegate>
 
+// Color of overlay shown behind image. Defaults to 60% opaque black
+@property (nonatomic, strong) UIColor *overlayColor;
 
 @property (nonatomic, assign) BOOL shouldBlurBackground;
 @property (nonatomic, assign) BOOL parallaxEnabled;

--- a/Pod/Classes/ENHViewController.m
+++ b/Pod/Classes/ENHViewController.m
@@ -13,7 +13,6 @@
 #import "UIView+SnapshotImage.h"
 
 
-static const CGFloat __overlayAlpha = 0.6f;						// opacity of the black overlay displayed below the focused image
 static const CGFloat __animationDuration = 0.18f;				// the base duration for present/dismiss animations (except physics-related ones)
 static const CGFloat __maximumDismissDelay = 0.5f;				// maximum time of delay (in seconds) between when image view is push out and dismissal animations begin
 static const CGFloat __resistance = 0.0f;						// linear resistance applied to the image’s dynamic item behavior
@@ -92,6 +91,7 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
     vc.shouldShowPhotoActions = NO;
     vc.shouldRotateToDeviceOrientation = YES;
     vc.shouldHideStatusBar = YES;
+    vc.overlayColor = [UIColor colorWithWhite:0 alpha:0.6];
     [vc allowTaps];
     
     return vc;
@@ -200,8 +200,6 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
     [self setupGestures];
     [self setupHierarchy];
     
-    self.backgroundView.backgroundColor = [UIColor colorWithWhite:0.0f alpha:__overlayAlpha];
-    
     self.imageView.layer.allowsEdgeAntialiasing = YES;
     
     [self.imageView addGestureRecognizer:self.doubleTapRecognizer];
@@ -265,6 +263,8 @@ static const CGFloat __blurTintColorAlpha = 0.2f;				// defines how much to tint
     self.imageView.transform = CGAffineTransformIdentity;
     self.imageView.image = image;
     self.imageView.alpha = 0.2;
+    
+    self.backgroundView.backgroundColor = self.overlayColor;
     
     // create snapshot of background if parallax is enabled
     if (self.parallaxEnabled || self.shouldBlurBackground) {


### PR DESCRIPTION
This allows the overlay background color to be changed before presenting any image. Still defaults to 60% opaque black.
